### PR TITLE
ページの読み込み中にメニューの残像が残らないようにした

### DIFF
--- a/app/assets/javascripts/js.js
+++ b/app/assets/javascripts/js.js
@@ -1,15 +1,14 @@
 $(document).ready(function() {
-  $('header nav').hide();
   $('#beBrotherAfter').hide();
   $('#unBrotherAfter').hide();
   var swNav = 0;
   
-  $('header h1').click(function(){
+  $('#brand').click(function(){
 	  if(swNav == 0){
-	    $('header nav').slideDown('fast');
+	    $('#nav').slideDown('fast');
 	    swNav = 1;
 	  }else{
-		  $('header nav').slideUp('fast');
+		  $('#nav').slideUp('fast');
 	    swNav = 0;
 	  }
   });

--- a/app/assets/stylesheets/css.css.scss
+++ b/app/assets/stylesheets/css.css.scss
@@ -146,7 +146,7 @@ input[type='submit'],
 	background: linear-gradient(#3579b0, #2371b0 50%, #1269b0 50%, #0060af);
 }
 
-header nav a.button {
+#nav a.button {
 	padding: 1em 0;
 	
 	font-size: 120%;
@@ -242,7 +242,7 @@ div#page {
 	margin: 0 auto;
 }
 
-header h1 {
+#brand {
   position: relative;
   float: left;
   width: 60px;
@@ -250,28 +250,29 @@ header h1 {
   cursor: pointer;
 }
 
-header h1 img {
+#brand img {
 	width: 100%;
 	height: auto;
 }
 
-header nav {
+#nav {
   position: relative;
   float: left;
 	width: 240px;
-	margin-left: 20px;
+	margin: 0 0 20px 20px;
+  display: none;
 }
 
-header nav ul li {
+#nav li {
   position: relative;
   float: left;
 }
 
 header,
-header nav ul,
+#nav ul,
 ul.brothers { zoom: 1; }
 header:after,
-header nav ul:after,
+#nav ul:after,
 ul.brothers:after { content: ""; display: block; clear: both; }
 
 /* details */

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,9 +1,9 @@
 %header#header
-  %h1
+  %h1#brand
     - num = rand(2)
     - brothers_source = 'brothers' + num.to_s() + '.png'
     = image_tag brothers_source, alt: 'まめぶろ'
-  %nav
+  %nav#nav
     %ul
       - if signed_in?
         %li


### PR DESCRIPTION
いままで JavaScript の読み込みが完了するまで .hide() の実行が遅れて、メニューの残像が残ることがありました。
今回の修正では CSS で display: none; するようにしたので、JavaScript の実行に関係なく残像が残らないようになりました。
