### PR TITLE
エントリー詳細に表示するブラザーネームは一文字目だけにした

### DIFF
--- a/app/views/entries/show.html.haml
+++ b/app/views/entries/show.html.haml
@@ -24,4 +24,4 @@
         = link_to "Delete", @entry, method: :delete, data: { confirm: "消えちゃうよ?" }, class: 'lsf-icon', title: 'delete'
     - else
       %a{href: "/brothers/#{@entry.brother.name}"}
-        = @entry.brother.name[0,1]
+        = @entry.brother.name[0,1].upcase + '.'


### PR DESCRIPTION
@mamebro/owners 
みられてる感を減らすために、エントリー詳細に表示するブラザーネームは一文字目だけにしました。
ブラザー一覧にいかないと誰の記事かわからないです :see_no_evil: 
