### PR TITLE
記事個別ページのイニシャルで表示しているブラザー名から一覧ページへのリンクを消した

### DIFF
--- a/app/views/entries/show.html.haml
+++ b/app/views/entries/show.html.haml
@@ -23,5 +23,4 @@
       %span.delete
         = link_to "Delete", @entry, method: :delete, data: { confirm: "消えちゃうよ?" }, class: 'lsf-icon', title: 'delete'
     - else
-      %a{href: "/brothers/#{@entry.brother.name}"}
-        = @entry.brother.name[0,1].upcase + '.'
+      = @entry.brother.name[0,1].upcase + '.'


### PR DESCRIPTION
@mamebro/owners 
実験的に、記事個別ページを見ただけでは誰が書いたかよくわからなくしてみようと思います。
