### PR TITLE
pre 要素, code 要素のスタイルを修正した

### DIFF
--- a/app/assets/stylesheets/entries.css.scss
+++ b/app/assets/stylesheets/entries.css.scss
@@ -182,6 +182,18 @@
     box-shadow: inset 0 1px 0 $silver;
   }
 
+  code {
+    padding: 0 $gap/2;
+    white-space: nowrap;
+    display: inline-block;
+    @include font(small);
+    font-family: Consolas, 'Liberation Mono', Courier, monospace;
+    line-height: 1.66;
+    background-color: $white;
+    border-radius: 3px;
+    box-shadow: inset 0 1px 0 $silver;
+  }
+
   blockquote {
     padding: 0 0 0 $gap;
     margin: 0 0 $gap/2 $gap/2;


### PR DESCRIPTION
@mamebro/owners 
日記で Markdown で pre 要素や code 要素を表示している場合に、
- pre 要素は monospace な書体を表示するべきが、iPhone の Safari でヒラギノが表示されてしまっていた問題を修正しました。
- code 要素にスタイルの指定がなかったので指定しました。

これにより、技術ブログの見た目がよくなります。
