### PR TITLE
pre 要素のなかの code 要素のスタイルを調整した

### DIFF
--- a/app/assets/stylesheets/entries.css.scss
+++ b/app/assets/stylesheets/entries.css.scss
@@ -186,12 +186,23 @@
     padding: 0 $gap/2;
     white-space: nowrap;
     display: inline-block;
-    @include font(small);
     font-family: Consolas, 'Liberation Mono', Courier, monospace;
+    font-size: 12px;
     line-height: 1.66;
     background-color: $white;
     border-radius: 3px;
     box-shadow: inset 0 1px 0 $silver;
+  }
+
+  pre code {
+    padding: 0;
+    white-space: pre;
+    display: inline;
+    font-size: 14px;
+    line-height: 1;
+    background-color: inherit;
+    border-radius: 0;
+    box-shadow: none;
   }
 
   blockquote {


### PR DESCRIPTION
#129 にあたって、さらに Markdown で pre 要素を表示しようとした場合は pre 要素のなかに code 要素がつくられることがわかったので、pre 要素のなかの code 要素のスタイルは code 要素だけのものとは違うスタイルを指定しました。
