### PR TITLE
日記の文章の行頭に句読点がこないようにした

### DIFF
--- a/app/assets/stylesheets/entries.css.scss
+++ b/app/assets/stylesheets/entries.css.scss
@@ -51,6 +51,9 @@
 
 .entry-content {
   margin-bottom: $gap;
+  text-align: justify;
+  word-break: normal;
+  word-wrap: break-word;
   @extend %font.default;
 
   p {


### PR DESCRIPTION
@mamebro/owners 
日記の文章の行頭に句読点がこないように、スタイルシートで指定しました。
#### 例
- Before

![2014-03-29 23 11 41](https://cloud.githubusercontent.com/assets/1396953/2558488/241767b0-b74c-11e3-9f8a-8c13270514d5.png)
- After

![2014-03-29 23 10 53](https://cloud.githubusercontent.com/assets/1396953/2558489/2a19c4f0-b74c-11e3-822a-b606d38135ee.png)
