### PR TITLE
ブラザーと兄弟のタイムラインを入れ替えた

### DIFF
--- a/app/controllers/timelines_controller.rb
+++ b/app/controllers/timelines_controller.rb
@@ -1,7 +1,11 @@
 class TimelinesController < ApplicationController
   def index
     if signed_in?
-      @entries = Entry.where.not(brother_id: current_brother.id).page params[:page]
+      followed_ids = []
+      Relationship.where(follower_id: current_brother.id).each do |rel|
+        followed_ids << rel.followed_id
+      end
+      @entries = Entry.where(brother_id: followed_ids).page params[:page]
     else
       @entries = Entry.page params[:page]
     end
@@ -10,12 +14,7 @@ class TimelinesController < ApplicationController
 
   def brothers
     if signed_in?
-      followed_ids = []
-      Relationship.where(follower_id: current_brother.id).each do |rel|
-        followed_ids << rel.followed_id
-      end
-      @entries = Entry.where(brother_id: followed_ids).page params[:page]
-      @entries.map{|e| e.content = e.content_as_markdown}
+      @entries = Entry.where.not(brother_id: current_brother.id).page params[:page]
     else
       redirect_to root_path
     end

--- a/app/views/timelines/_navs.html.haml
+++ b/app/views/timelines/_navs.html.haml
@@ -2,7 +2,7 @@
   %ul{class: "nav-pill-wrapper current-#{current_page}"}
     %li.nav-pill.nav-pill-index
       %a{href: '/'}
-        ブラザー
+        兄弟
     %li.nav-pill.nav-pill-brothers
       %a{href: '/timelines/brothers'}
-        兄弟
+        ブラザー


### PR DESCRIPTION
@mamebro/owners 
http://mameblo.com/entries/3983 から、たしかにそうかもなあと思い、ブラザーと兄弟のタイムラインを入れ替えました。
整理すると、この pull request をマージすると各ページの機能は以下のようになります。
#### サインインしてない人
- mameblo.com/
  - すべてのブラザーの日記の一覧
- mameblo.com/timelines/brothers
  - トップページへリダイレクト
#### サインインしてる人
- mameblo.com/
  - 兄弟になったブラザーの日記の一覧
- mameblo.com/timelines/brothers
  - 自分を除くすべてのブラザーの日記の一覧
