### PR TITLE
サインイン画面で Tab キー押したときにパスワード再設定フォームへのリンクに focus が当たらないようになった

### DIFF
--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -6,7 +6,7 @@
       = form_for(:session, url: sessions_path) do |f|
         = f.text_field :name, class: 'input input-text', placeholder: 'BrotherName'
         %div.password-field-wrapper
-          = link_to new_password_reset_path, class: 'icon password-forget' do
+          = link_to new_password_reset_path, class: 'icon password-forget', tabindex: '-1' do
             &#59140;
           = f.password_field :password, class: 'input input-text', placeholder: 'Password'
         = f.submit "兄弟元気かな", class: "button button-horizontal button-primary"


### PR DESCRIPTION
@mamebro/owners 
サインイン画面で Tab キー押したときに、パスワード再設定フォームへのリンクに focus が当たらないように tabindex に負の値を指定しました。
@2get が報告してくれた！ありがとう！
