### PR TITLE
日記を書いてる途中でブラウザを閉じても書いてた内容を覚えてくれているようにした

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -39,7 +39,7 @@ $(function() {
   });
 
   $entryForm.submit(function() {
-    clearLocalStorage();
+    clearDraft();
   });
 
   $('.nav-editor-control').click(function() {
@@ -47,7 +47,7 @@ $(function() {
     if ($body.hasClass('is-editor')) {
       if ($entryForm.hasClass('submittable')) {
         if (window.confirm('投稿しなくて大丈夫？')) {
-          clearLocalStorage();
+          clearDraft();
           $body.removeClass('is-editor');
         }
       } else {
@@ -70,7 +70,7 @@ $(function() {
     checkSubmittable();
   });
 
-  function clearLocalStorage() {
+  function clearDraft() {
     localStorage.clear('entryFormTitle');
     localStorage.clear('entryFormContent');
     $entryFormTitle.val('');


### PR DESCRIPTION
@mamebro/owners 
日記を書いてるときに内容を localStorage に保存できるようにしました。
書いてる途中でブラウザを閉じたりリロードしても、localStorage に保存されているので、またまめぶろにアクセスして投稿フォームを開けばつづきから書くことができます。
日記を書き終わって送信するときや、「書く」を閉じるときは、localStorage に保存した内容を削除します。
とりあえず新しい投稿を書くときだけ機能して、投稿を編集するときには機能しません。
