### PR TITLE
投稿フォームの内容を送信するときにフォームの内容を削除してしまっていたので修正した

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -48,6 +48,8 @@ $(function() {
       if ($entryForm.hasClass('submittable')) {
         if (window.confirm('投稿しなくて大丈夫？')) {
           clearDraft();
+          $entryFormTitle.val('');
+          $entryFormContent.val('');
           $body.removeClass('is-editor');
         }
       } else {
@@ -73,8 +75,6 @@ $(function() {
   function clearDraft() {
     localStorage.clear('entryFormTitle');
     localStorage.clear('entryFormContent');
-    $entryFormTitle.val('');
-    $entryFormContent.val('');
   }
 
   function checkSubmittable() {


### PR DESCRIPTION
@mamebro/owners 
#200 で「日記を書いてる途中でブラウザを閉じても書いてた内容を覚えてくれているようにした」をリリースしましたが、そこで日記を投稿するために送信する前にフォームの内容を削除してしまっていて、投稿できない不具合がありました。申し訳ありませんでした！

投稿フォームの内容を送信するときに実行する関数からフォームの内容を削除する処理を削除して、必要なときだけフォームの内容を削除するようにしました。
