### PR TITLE
サインアウトしてるときにメニューが開かない問題を修正した

### DIFF
--- a/app/assets/javascripts/editor.js
+++ b/app/assets/javascripts/editor.js
@@ -3,17 +3,17 @@ $(function() {
       $entryFormTitle = $entryForm.find('#entry-form-title'),
       $entryFormContent = $entryForm.find('#entry-form-content');
 
-  if (0 < $entryForm.size()) {
-    $entryFormTitle
-      .val(localStorage.getItem('entryFormTitle'));
-    $entryFormContent
-      .val(localStorage.getItem('entryFormContent'))
-      .attr('data-rows-original', $entryFormContent.attr('rows'));
+  if ($entryForm.size() <= 0) { return; }
 
-    checkSubmittable();
+  $entryFormTitle
+    .val(localStorage.getItem('entryFormTitle'));
+  $entryFormContent
+    .val(localStorage.getItem('entryFormContent'))
+    .attr('data-rows-original', $entryFormContent.attr('rows'));
 
-    $('textarea').autosize();
-  }
+  checkSubmittable();
+
+  $('textarea').autosize();
 
   $entryFormTitle.bind('keyup', function() {
     // 入力した文字を保存する


### PR DESCRIPTION
@mamebro/owners 
投稿フォームの文字数を数える JavaScript が、サインアウトしてるとき（投稿フォームが表示されてないとき）にも実行しようとして値が undefined になってエラーになってメニューが開かなくなっていたので、投稿フォームが表示されてないときは投稿フォームを読み込んだときに実行する JavaScript を実行しないようにしました。
