### PR TITLE
s3に送った後にdumpファイルをgzipする

### DIFF
--- a/lib/tasks/db_backup.rake
+++ b/lib/tasks/db_backup.rake
@@ -4,5 +4,6 @@ namespace :db do
   task :backup => :environment do
     system "mysqldump -u #{ENV['SQALE_USERNAME']} -h #{ENV['SQALE_HOST']} -p #{ENV['SQALE_DATABASE']} --password=#{ENV['SQALE_PASSWORD']} > ../tmp/#{Time.now.strftime('%Y%m%d')}-mameblo-mysql.dump"
     system "s3cmd put ../tmp/#{Time.now.strftime('%Y%m%d')}-mameblo-mysql.dump s3://mameblo-backup/#{Time.now.year}/#{Time.now.month}/"
+    system "gzip ../tmp/#{Time.now.strftime('%Y%m%d')}-mameblo-mysql.dump"
   end
 end


### PR DESCRIPTION
@shikakun @sushiyama @kitak 
Sqaleの容量制限に引っかかってしまうので :camel: 

あとで、定期的にdumpファイルを掃除するやつもいれます。
