### PR TITLE
まめぶろ広告の ロリポタッチ+ のアプリのダウンロード URL を変更した

### DIFF
--- a/app/views/shared/_ad.html.haml
+++ b/app/views/shared/_ad.html.haml
@@ -1,2 +1,2 @@
-%a.ad{href: 'https://itunes.apple.com/jp/app/id921378588', target: '_blank', onclick: "ga('send', 'event', 'ad_lolipotouchplus', 'click');"}
+%a.ad{href: 'http://ad.apps.fm/eby5phtraWjg-nYP5Mz-ivE7og6fuV2oOMeOQdRqrE3NYIj_jK6kJg_NBsb6N2ea1tTkdSNI6XEpopE74OwJe6BM8pawSfeHGJ9OplhYMEM', target: '_blank', onclick: "ga('send', 'event', 'ad_lolipotouchplus', 'click');"}
   こんにちは。まめぶろの競合 iPhone アプリ、ロリポタッチ+です。1分でシャレオツ Web サイトが作れます。


### PR DESCRIPTION
まめぶろ経由でダウンロードした数を計測するために、ロリポタッチ+ のアプリのダウンロード URL を変更しました。
