### PR TITLE
Add name validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'uglifier'
 gem 'rack-google-analytics'
 gem 'awesome_print'
 
+gem 'resource_name_validator'
+
 group :production do
   gem 'mysql2', '~> 0.3.20'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,8 @@ GEM
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
     ref (2.0.0)
+    resource_name_validator (0.1.0)
+      activemodel
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
     sass (3.4.21)
@@ -373,6 +375,7 @@ DEPENDENCIES
   rails (~> 5.0.0.beta3)
   rb-fsevent
   redcarpet
+  resource_name_validator
   responders
   rspec!
   rspec-core!

--- a/app/models/brother.rb
+++ b/app/models/brother.rb
@@ -26,6 +26,7 @@ class Brother < ActiveRecord::Base
     length: {within: 3..20},
     format: { with: VALID_NAME_REGEX },
     uniqueness: true,
+    resource_name: true,
     exclusion: { in: RESERVED_NAMES, message: "そういう名前は名乗れないよ。" }
 
   validates :password, presence: true, length: { minimum: 6 }

--- a/spec/models/brother_spec.rb
+++ b/spec/models/brother_spec.rb
@@ -47,6 +47,11 @@ describe Brother do
     it { is_expected.not_to be_valid }
   end
 
+  describe "resource name is defined" do
+    before { @brother.name = "discover" }
+    it { is_expected.not_to be_valid }
+  end
+
   describe "resource name is not defined" do
     before { @brother.name = "discove" }
     it { is_expected.to be_valid }

--- a/spec/models/brother_spec.rb
+++ b/spec/models/brother_spec.rb
@@ -47,6 +47,11 @@ describe Brother do
     it { is_expected.not_to be_valid }
   end
 
+  describe "resource name is not defined" do
+    before { @brother.name = "discove" }
+    it { is_expected.to be_valid }
+  end
+
   describe "when name format is invalid" do
     it "should be invalid" do
       brothername = %w[@@@, #, ||, ---, www.nakaotakashi.com]


### PR DESCRIPTION
@shikakun 
https://github.com/kurotaky/resource_name_validator というRailsのroutesで定義済みのnameを
検証するgemを作ってみたので入れてみます。
例えば `http://mameblo.com/discover` がroutesで定義されていたら、
`brother#name` として`discover`という名前が取得できないようにできます。